### PR TITLE
Add support for predicates

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,17 +39,19 @@ expect(output).to.emit([
 ### `expect` / `should` syntax
 
 ```javascript
-const const xs = scheduler.createHotObservable(onNext(250, { 'foo': 'bar' }));
+const xs = scheduler.createHotObservable(onNext(250, { 'foo': 'bar' }), onError(300, new Error('An error')));
 const output = scheduler.startScheduler(() => xs);
 
 // expect
 expect(output).to.emit([
-  onNext(250, { 'foo': 'bar' })
+  onNext(250, { 'foo': 'bar' }),
+  onError(300, ({error}) => error.message === 'An error')
 ]);
 
 // should
 output.should.emit([
-  onNext(250, { 'foo': 'bar' })
+  onNext(250, { 'foo': 'bar' }),
+  onError(300, ({error}) => error.message === 'An error')
 ]);
 ```
 

--- a/lib/chai-rx.js
+++ b/lib/chai-rx.js
@@ -29,7 +29,7 @@
   function createMessage(expected, actual) {
     return 'Expected: [' + JSON.stringify(expected) + ']\r\nActual: [' + JSON.stringify(actual) + ']';
   }
-
+  // see https://github.com/Reactive-Extensions/RxJS/blob/master/tests/helpers/reactiveassert.js
   function chaiRx(chai, _utils) {
     chai.Assertion.addMethod('emit', function emitAssertion(expected) {
       var obj = this._obj;
@@ -44,7 +44,15 @@
       }
 
       for (var i = 0, len = expected.length; i < len; i++) {
-        isOk = comparer(expected[i], actual[i]);
+        var e = expected[i],
+            a = actual[i];
+        // Allow for predicates
+        if (e.value && typeof e.value.predicate === 'function') {
+          isOk = e.time === a.time && e.value.predicate(a.value);
+        } else {
+          isOk = comparer(e, a);
+        }
+
         if (!isOk) {
           break;
         }

--- a/src/chai-rx.js
+++ b/src/chai-rx.js
@@ -3,7 +3,7 @@ import Rx from 'rx';
 function createMessage(expected, actual) {
   return `Expected: [${JSON.stringify(expected)}]\r\nActual: [${JSON.stringify(actual)}]`;
 }
-
+// see https://github.com/Reactive-Extensions/RxJS/blob/master/tests/helpers/reactiveassert.js
 export default function chaiRx(chai, _utils) {
   chai.Assertion.addMethod('emit', function emitAssertion(expected) {
     const obj = this._obj;
@@ -18,7 +18,14 @@ export default function chaiRx(chai, _utils) {
     }
 
     for (let i = 0, len = expected.length; i < len; i++) {
-      isOk = comparer(expected[i], actual[i]);
+      var e = expected[i], a = actual[i];
+      // Allow for predicates
+      if (e.value && typeof e.value.predicate === 'function') {
+        isOk = e.time === a.time && e.value.predicate(a.value);
+      } else {
+        isOk = comparer(e, a);
+      }
+
       if (!isOk) {
         break;
       }

--- a/test/chai-rx.spec.js
+++ b/test/chai-rx.spec.js
@@ -1,5 +1,5 @@
 import Rx from 'rx';
-const { onNext, onCompleted } = Rx.ReactiveTest;
+const { onNext, onError, onCompleted } = Rx.ReactiveTest;
 
 describe('chai-rx', () => {
   describe('emit', () => {
@@ -64,20 +64,22 @@ describe('chai-rx', () => {
 
       describe('`expect` usage', () => {
         it('should pass with `expect`', () => {
-          const xs = scheduler.createHotObservable(onNext(250, { 'foo': 'bar' }));
+          const xs = scheduler.createHotObservable(onNext(250, { 'foo': 'bar' }), onError(300, new Error('An error')));
           const output = scheduler.startScheduler(() => xs);
           expect(output).to.emit([
-            onNext(250, { 'foo': 'bar' })
+            onNext(250, { 'foo': 'bar' }),
+            onError(300, ({error}) => error.message === 'An error')
           ]);
         });
       });
 
       describe('`should` usage', () => {
         it('should pass with `should`', () => {
-          const xs = scheduler.createHotObservable(onNext(250, { 'foo': 'bar' }));
+          const xs = scheduler.createHotObservable(onNext(250, { 'foo': 'bar' }), onError(300, new Error('An error')));
           const output = scheduler.startScheduler(() => xs);
           output.should.emit([
-            onNext(250, { 'foo': 'bar' })
+            onNext(250, { 'foo': 'bar' }),
+            onError(300, ({error}) => error.message === 'An error')
           ]);
         });
       });


### PR DESCRIPTION
ReactiveTest supports custom assertions in messages. This PR adds such functionality to chai-rx