### PR TITLE
Enable rxjs 5+ library

### DIFF
--- a/lib/chai-rx.js
+++ b/lib/chai-rx.js
@@ -1,16 +1,16 @@
 (function (global, factory) {
   if (typeof define === "function" && define.amd) {
-    define(['exports', 'rx'], factory);
+    define(['exports', 'lodash'], factory);
   } else if (typeof exports !== "undefined") {
-    factory(exports, require('rx'));
+    factory(exports, require('lodash'));
   } else {
     var mod = {
       exports: {}
     };
-    factory(mod.exports, global.rx);
+    factory(mod.exports, global.lodash);
     global.chaiRx = mod.exports;
   }
-})(this, function (exports, _rx) {
+})(this, function (exports, _) {
   'use strict';
 
   Object.defineProperty(exports, "__esModule", {
@@ -18,16 +18,9 @@
   });
   exports.default = chaiRx;
 
-  var _rx2 = _interopRequireDefault(_rx);
-
-  function _interopRequireDefault(obj) {
-    return obj && obj.__esModule ? obj : {
-      default: obj
-    };
-  }
 
   function createMessage(expected, actual) {
-    return 'Expected: [' + JSON.stringify(expected) + ']\r\nActual: [' + JSON.stringify(actual) + ']';
+    return 'Expected: \r\n' + JSON.stringify(expected) + '\r\nActual: \r\n' + JSON.stringify(actual);
   }
   // see https://github.com/Reactive-Extensions/RxJS/blob/master/tests/helpers/reactiveassert.js
   function chaiRx(chai, _utils) {
@@ -35,7 +28,6 @@
       var obj = this._obj;
       var actual = obj.messages;
 
-      var comparer = _rx2.default.internals.isEqual;
       var isOk = true;
 
       if (expected.length !== actual.length) {
@@ -50,7 +42,7 @@
         if (e.value && typeof e.value.predicate === 'function') {
           isOk = e.time === a.time && e.value.predicate(a.value);
         } else {
-          isOk = comparer(e, a);
+          isOk = _.isEqual(e, a);
         }
 
         if (!isOk) {

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "chai-rx",
+  "name": "chai-rxjs",
   "version": "0.0.3",
-  "description": "Extends Chai with assertions about RxJS observable streams.",
-  "main": "lib/chai-rx.js",
+  "description": "Extends Chai with assertions about RxJS5+ observable streams.",
+  "main": "lib/chai-rxjs.js",
   "scripts": {
     "build": "./node_modules/.bin/babel src -d lib",
     "test": "mocha test/chai-rx.spec.js"
@@ -29,7 +29,7 @@
   },
   "homepage": "https://github.com/hellosmithy/chai-rx#readme",
   "peerDependencies": {
-    "rx": ">= 4.0.7 < 5",
+    "rxjs": ">= 5",
     "chai": ">= 2.1.2 < 4.2"
   },
   "devDependencies": {
@@ -39,6 +39,9 @@
     "babel-register": "^6.9.0",
     "chai": "^4.0.2",
     "mocha": "^2.5.3",
-    "rx": "^4.1.0"
+    "rxjs": "^5.5.6"
+  },
+  "dependencies": {
+    "lodash": "^4.17.5"
   }
 }

--- a/src/chai-rx.js
+++ b/src/chai-rx.js
@@ -1,7 +1,7 @@
-import Rx from 'rx';
+const _ = require('lodash');
 
 function createMessage(expected, actual) {
-  return `Expected: [${JSON.stringify(expected)}]\r\nActual: [${JSON.stringify(actual)}]`;
+  return `Expected: \r\n${JSON.stringify(expected)}\r\nActual: \r\n${JSON.stringify(actual)}`;
 }
 // see https://github.com/Reactive-Extensions/RxJS/blob/master/tests/helpers/reactiveassert.js
 export default function chaiRx(chai, _utils) {
@@ -9,7 +9,6 @@ export default function chaiRx(chai, _utils) {
     const obj = this._obj;
     const actual = obj.messages;
 
-    const comparer = Rx.internals.isEqual;
     let isOk = true;
 
     if (expected.length !== actual.length) {
@@ -23,7 +22,7 @@ export default function chaiRx(chai, _utils) {
       if (e.value && typeof e.value.predicate === 'function') {
         isOk = e.time === a.time && e.value.predicate(a.value);
       } else {
-        isOk = comparer(e, a);
+        isOk = _.isEqual(e, a);
       }
 
       if (!isOk) {


### PR DESCRIPTION
Couple if things about this PR:
* some internal functionality of rx was completely removed (e.g. `internals.isEqual`) hence I added dependency on `lodash` for deep object equality
* I am not sure if `./lib` directory should be ignored (but still generated when building) -- essentially the code is duplicated ... imho should be ignored if possible
* rx has a different `TestScheduler` where `startScheduler` no longer exists, in one of the tests so I wasn't able to simulate the late subscription without having a negative timed event (I think `createHotObservable` should handle such case, but still the first event, prior to subscription, was still emitted).
* rx marbles could be simplified (reduce the number of '-' chars)